### PR TITLE
feat: install spark operator to k8s cluster

### DIFF
--- a/src/projects/aws-eks/index.ts
+++ b/src/projects/aws-eks/index.ts
@@ -462,7 +462,7 @@ const sparkOperatorRelease = new k8s.helm.v3.Chart(
         enabled: true
       },
       image: {
-        tag: 'v1beta2-1.1.2-2.4.5'
+        tag: 'v1beta2-1.2.3-3.1.1'
       },
       sparkJobNamespace: aiAppsNs.id,
       serviceAccounts: {


### PR DESCRIPTION
- Install spark-operator using helm Chart to k8s. Ref: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator
- Using `k8s.helm.v3.Chart` instead of k8s.helm.v3.Release because Release does not generate desired state as Chart
- Spark operator base version 3.1.1 but tested running Spark 2.4.5 application still work
- Install spark-operator to aitomatic-infra namespace and restrict can only run Spark application in aitomatic-apps namespace
- Pretty format for ts file