### PR TITLE
feat: enable webhook in spark operator

### DIFF
--- a/src/projects/aws-eks/index.ts
+++ b/src/projects/aws-eks/index.ts
@@ -486,6 +486,9 @@ const sparkOperatorChart = new k8s.helm.v3.Chart(
         sparkoperator: {
           name: 'spark-operator'
         }
+      },
+      webhook: {
+        enable: true
       }
     }
   },


### PR DESCRIPTION
To support some features like: 
- Mounting ConfigMaps
- Mounting Volumes
- Requesting GPU Resources
- etc.

Ref: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/master/docs/user-guide.md