### PR TITLE
Fix: Change fluentbit setting to push logs to ES more often and have bigger buffer size to store log temporary in pod

### DIFF
--- a/src/projects/aws-eks/index.ts
+++ b/src/projects/aws-eks/index.ts
@@ -1077,7 +1077,7 @@ const jh = new k8s.helm.v3.Release(
 const fluentBitServiceConfig = `
 [SERVICE]
     Daemon Off
-    Flush 5
+    Flush 1
     Log_Level info
     Parsers_File parsers.conf
     Parsers_File custom_parsers.conf
@@ -1085,10 +1085,6 @@ const fluentBitServiceConfig = `
     HTTP_Listen 0.0.0.0
     HTTP_Port 2020
     Health_Check On
-    storage.path /var/log/flb-storage/
-    storage.sync normal
-    storage.checksum off
-    storage.backlog.mem_limit 10M
 `;
 const fluentBitInputConfig = `
 [INPUT]
@@ -1098,7 +1094,9 @@ const fluentBitInputConfig = `
     Tag kube.*
     Mem_Buf_Limit 5MB
     Skip_Long_Lines On
-    storage.type filesystem
+    Skip_Empty_Lines On
+    Buffer_Chunk_Size 1MB
+    Buffer_Max_Size 1MB
 
 [INPUT]
     Name systemd
@@ -1155,7 +1153,6 @@ const fluentBitOutputConfig = `
     Logstash_Prefix logs
     Retry_Limit False
     Replace_Dots On
-    storage.total_limit_size  10M
     
 [OUTPUT]
     Name es


### PR DESCRIPTION
- Change flush time from 5s to 1s
- Increase buffer size from 32kb to 1mb
- Remove setting for backpressure